### PR TITLE
Add reverse proxy for guacamole / HTML5 RDP tunnel in Caddy config.

### DIFF
--- a/dockercompose/caddy/Caddyfile.template
+++ b/dockercompose/caddy/Caddyfile.template
@@ -15,4 +15,7 @@ DOMAIN_NAME {
         uri strip_prefix /uds/res
         file_server
     }
+    handle /guacamole/* {
+        reverse_proxy @notStatic guacamole:8080
+    }
 }


### PR DESCRIPTION
This allows using same port/certificate for UDS broker and HTML5 RDP transport.