### PR TITLE
Add missing dependency

### DIFF
--- a/building/broker/DockerFile
+++ b/building/broker/DockerFile
@@ -19,6 +19,7 @@ RUN apt update && apt install -y \
     libpangoft2-1.0-0 \
     libmemcached-dev \
     libmariadb-dev \
+    libldap-dev \
     tzdata \
     libxmlsec1-dev     \
     pkg-config \


### PR DESCRIPTION
libldap-dev is not installed in broker image, so LDAP based authenticators  are not working